### PR TITLE
Changed the original Faker to FakerPHP/Faker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,20 @@ A growing collection of useful Providers for [fzaninotto/faker](https://github.c
 ## Installation
 
 ```bash
-composer require xylis/faker-cinema-providers
+composer require djyp/faker-cinema-providers
 ```
 
 ## Formatters
 
 Below is the list of bundled formatters in the default locale.
 
-### `Xylis\FakerCinema\Provider\Movie`
+### `QuiGon\FakerCinema\Provider\Movie`
 
 ```php
 <?php
 
 $faker = \Faker\Factory::create();
-$faker->addProvider(new \Xylis\FakerCinema\Provider\Movie($faker));
+$faker->addProvider(new \QuiGon\FakerCinema\Provider\Movie($faker));
 
 $faker->movie; // Saving Private Ryan
 $faker->studio; // 20th Century Fox
@@ -47,13 +47,13 @@ $faker->movieGenres(2); // array('Drama', 'Comedy');
 
 ```
 
-### `Xylis\FakerCinema\Provider\TvShow`
+### `QuiGon\FakerCinema\Provider\TvShow`
 
 ```php
 <?php
 
 $faker = \Faker\Factory::create();
-$faker->addProvider(new \Xylis\FakerCinema\Provider\TvShow($faker));
+$faker->addProvider(new \QuiGon\FakerCinema\Provider\TvShow($faker));
 
 $faker->tvShow; // Breaking Bad
 $faker->tvNetwork; // HBO
@@ -68,13 +68,13 @@ $faker->tvNetworks(2); // array('Netflix', 'ABC')
 $faker->showGenres(2); // array('Drama', 'Sitcom')
 
 ```
-### `Xylis\FakerCinema\Provider\Person`
+### `QuiGon\FakerCinema\Provider\Person`
 
 ```php
 <?php
 
 $faker = \Faker\Factory::create();
-$faker->addProvider(new \Xylis\FakerCinema\Provider\Person($faker));
+$faker->addProvider(new \QuiGon\FakerCinema\Provider\Person($faker));
 
 $faker->actor; // Cate Blanchett
 $faker->femaleActor; // Emma Stone
@@ -107,7 +107,7 @@ $faker->femalePersons($count = 2, $duplicates = false); // array('Agnès Varda',
 $faker->malePersons($count = 2, $duplicates = false); // array('Denis Villeneuve', 'Leonardo Dicaprio');
 ```
 
-### `Xylis\FakerCinema\Provider\Character`
+### `QuiGon\FakerCinema\Provider\Character`
 
 Generates product and department data for e-commerce websites and online stores.
 
@@ -115,7 +115,7 @@ Generates product and department data for e-commerce websites and online stores.
 <?php
 
 $faker = \Faker\Factory::create();
-$faker->addProvider(new \Xylis\FakerCinema\Provider\Character($faker));
+$faker->addProvider(new \QuiGon\FakerCinema\Provider\Character($faker));
 
 $faker->character($gender = null); // Skyler White
 $faker->character($gender = 'male'); // Darth Vader

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "xylis/faker-cinema-providers",
-  "description": "Generate random movie & shows datas using fzaninotto/Faker (based on real names & datas)",
+  "name": "djyp/faker-cinema-providers",
+  "description": "Generate random movie & shows datas using fakerphp/Faker (based on real names & datas)",
   "minimum-stability": "stable",
   "license": "MIT",
   "type": "library",
@@ -8,6 +8,10 @@
     {
       "name": "Julien RAVIA",
       "email": "julien.ravia@gmail.com"
+    },
+    {
+      "name": "Djyp Forest Fortin",
+      "email": "djyp@oclock.io"
     }
   ],
   "require": {
@@ -16,7 +20,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Xylis\\FakerCinema\\": "src/"
+      "QuiGon\\FakerCinema\\": "src/"
     }
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": "^5.3.3 || ^7.0",
-    "fzaninotto/faker": "~1"
+    "fakerphp/faker": "~1"
   },
   "autoload": {
     "psr-4": {

--- a/src/Provider/BaseProvider.php
+++ b/src/Provider/BaseProvider.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Xylis\FakerCinema\Provider;
+namespace QuiGon\FakerCinema\Provider;
 
 use Faker\Provider\Base as FakerProvider;
 
 /**
- * @package Xylis\FakerCinema
+ * @package QuiGon\FakerCinema
  */
 abstract class BaseProvider extends FakerProvider
 {

--- a/src/Provider/Character.php
+++ b/src/Provider/Character.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Xylis\FakerCinema\Provider;
+namespace QuiGon\FakerCinema\Provider;
 
-use Xylis\FakerCinema\Provider\BaseProvider;
+use QuiGon\FakerCinema\Provider\BaseProvider;
 
 class Character extends BaseProvider
 {

--- a/src/Provider/Movie.php
+++ b/src/Provider/Movie.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Xylis\FakerCinema\Provider;
+namespace QuiGon\FakerCinema\Provider;
 
-use Xylis\FakerCinema\Provider\BaseProvider;
+use QuiGon\FakerCinema\Provider\BaseProvider;
 
 /**
  * @author Xylis <julien.ravia@gmail.com>
- * @package Xylis\FakerCinema
+ * @package QuiGon\FakerCinema
  */
 class Movie extends BaseProvider
 {

--- a/src/Provider/Person.php
+++ b/src/Provider/Person.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Xylis\FakerCinema\Provider;
+namespace QuiGon\FakerCinema\Provider;
 
-use Xylis\FakerCinema\Provider\BaseProvider;
+use QuiGon\FakerCinema\Provider\BaseProvider;
 
 /**
  * @author Xylis <julien.ravia@gmail.com>
- * @package Xylis\FakerCinema
+ * @packag QuiGon\FakerCinema
  */
 class Person extends BaseProvider
 {

--- a/src/Provider/TvShow.php
+++ b/src/Provider/TvShow.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Xylis\FakerCinema\Provider;
+namespace QuiGon\FakerCinema\Provider;
 
-use Xylis\FakerCinema\Provider\BaseProvider;
+use QuiGon\FakerCinema\Provider\BaseProvider;
 
 /**
  * @author Xylis <julien.ravia@gmail.com>
- * @package Xylis\FakerCinema
+ * @package QuiGon\FakerCinema
  */
 class TvShow extends BaseProvider
 {


### PR DESCRIPTION
Hello ! Bonjour !

The fzaninotto/faker dependency has been deprecated in october, its author stopped developping it. FakerPHP/Faker replaces it with total compatibility and is compatible with PHP8.